### PR TITLE
refactor: remove deprecated tag usage detection

### DIFF
--- a/commands/tag_command.py
+++ b/commands/tag_command.py
@@ -24,9 +24,7 @@ from db.sqlite_handler import (
 )
 from helper import (
     build_embed,
-    find_old_tag_in_string,
     find_tag_in_string,
-    sentry_capture,
     tag_exists,
 )
 from modals import AddTagModal, UpdateTagModal
@@ -251,19 +249,6 @@ class TagCommands(commands.Cog):
         - None
         """
         if message.author == self.bot.user or not message.content:
-            return
-
-        if find_old_tag_in_string(message.content):
-            tag = find_old_tag_in_string(message.content)[0]
-            sentry_capture(
-                Exception(f"Deprecated tag usage: {tag}"),
-                server_id=message.guild.id,
-                user_id=message.author.id,
-            )
-            await message.channel.send(
-                f"Deprecated `%` uses, please consider using new trigger character `§{tag}`",
-                delete_after=5,
-            )
             return
 
         if find_tag_in_string(message.content):

--- a/helper.py
+++ b/helper.py
@@ -126,19 +126,3 @@ def find_tag_in_string(s):
     """
     tags = re.findall(r"§(\w+[-\w]*)", s)
     return tags
-
-
-def find_old_tag_in_string(s):
-    """
-    Deprecated function to find old tags in a string.
-
-    Finds and returns tags within a string that start with '%'.
-
-    Args:
-        s (str): The input string to search for tags.
-
-    Returns:
-        list: A list of tags found in the input string.
-    """
-    tags = re.findall(r"%(\w+[-\w]*)", s)
-    return tags


### PR DESCRIPTION
- Removed `find_old_tag_in_string` function and its associated import and usage.
- Updated `tag_command.py` to eliminate checks for old tags starting with `%`.
- Cleaned up `helper.py` by deleting the deprecated `find_old_tag_in_string` function.